### PR TITLE
Allow no linear models to be created

### DIFF
--- a/GENet/__init__.py
+++ b/GENet/__init__.py
@@ -1337,7 +1337,7 @@ class PlainNet(nn.Module):
 
         self.last_channels = self.adptive_avg_pool.out_channels
 
-        if proj:
+        if not proj:
             self.fc_linear = None
         else:
             self.fc_linear = nn.Linear(self.last_channels, self.num_classes, bias=True)

--- a/GENet/__init__.py
+++ b/GENet/__init__.py
@@ -1312,6 +1312,9 @@ _all_netblocks_dict_ = {
 }
 
 
+def exists(val):
+    return val is not None
+
 class PlainNet(nn.Module):
     def __init__(self, num_classes=None, plainnet_struct=None, no_create=False, **kwargs):
         super(PlainNet, self).__init__(**kwargs)
@@ -1348,7 +1351,8 @@ class PlainNet(nn.Module):
 
         output = self.adptive_avg_pool(output)
         output = torch.flatten(output, 1)
-        output = self.fc_linear(output)
+        if exists(self.fc_linear):
+            output = self.fc_linear(output)
         return output
 
 def genet_large(pretrained=False, num_classes=1000, root='./GENet_params'):

--- a/GENet/__init__.py
+++ b/GENet/__init__.py
@@ -1316,7 +1316,7 @@ def exists(val):
     return val is not None
 
 class PlainNet(nn.Module):
-    def __init__(self, num_classes=None, plainnet_struct=None, no_create=False, **kwargs):
+    def __init__(self, num_classes=None, plainnet_struct=None, proj=True, no_create=False, **kwargs):
         super(PlainNet, self).__init__(**kwargs)
         self.num_classes = num_classes
         self.plainnet_struct = plainnet_struct
@@ -1337,7 +1337,7 @@ class PlainNet(nn.Module):
 
         self.last_channels = self.adptive_avg_pool.out_channels
 
-        if no_create:
+        if proj:
             self.fc_linear = None
         else:
             self.fc_linear = nn.Linear(self.last_channels, self.num_classes, bias=True)


### PR DESCRIPTION
This allows users to define an image encoder without the linear project layers, this will be useful if someone wants to use GENet for other vision task using GENet as an feature extraction

Changes:

* check whether fc_linear exists, since fc_linear is allow to be None value. This should be considered a bug fix

* added new proj=True/False parameters to allow creation of models without linear projection
